### PR TITLE
MIME4J-262 bugfix of MessageBuilder regarding getDate

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,22 @@
+Release 0.9.0
+-------------------
+
+Fix MIME4J-262 without breaking compatibility with old code by deprecating:
+ * MessageBuilder#MessageBuilder()
+ * MessageBuilder#create()
+ * MessageBuilder#createCopy(Message)
+ * MessageBuilder#read(InputStream)
+
+and adding:
+ * MessageBuilder#of()
+ * MessageBuilder#of(Message)
+ * MessageBuilder#of(InputStream)
+
+MessageBuilder constructed by of methods produce message for which the getDate method return null if and only if the
+message do not have a "Date" header. Whereas MessageBuilder constructed by deprecated method produce message for which
+the getDate method never return null: if the message has no "Date" header the returned value is "new Date()" result when
+the message has been instantiated
+
 Release 0.7.2
 -------------------
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,21 +1,11 @@
 Release 0.9.0
 -------------------
 
-Fix MIME4J-262 without breaking compatibility with old code by deprecating:
- * MessageBuilder#MessageBuilder()
- * MessageBuilder#create()
- * MessageBuilder#createCopy(Message)
- * MessageBuilder#read(InputStream)
+Fix MIME4J-262 without breaking compatibility with old code by deprecating MessageBuilder and adding Message.Builder
 
-and adding:
- * MessageBuilder#of()
- * MessageBuilder#of(Message)
- * MessageBuilder#of(InputStream)
-
-MessageBuilder constructed by of methods produce message for which the getDate method return null if and only if the
-message do not have a "Date" header. Whereas MessageBuilder constructed by deprecated method produce message for which
-the getDate method never return null: if the message has no "Date" header the returned value is "new Date()" result when
-the message has been instantiated
+Message.Builder produce message for which the getDate method return null if and only if the message do not have a "Date"
+header. Whereas MessageBuilder will produce message for which the getDate method never return null: if the message has
+no "Date" header the returned value is "new Date()" result when the message has been instantiated
 
 Release 0.7.2
 -------------------

--- a/dom/src/main/java/org/apache/james/mime4j/dom/Message.java
+++ b/dom/src/main/java/org/apache/james/mime4j/dom/Message.java
@@ -24,6 +24,45 @@ import java.util.Date;
 import org.apache.james.mime4j.dom.address.AddressList;
 import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.dom.address.MailboxList;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
+
+import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.MimeIOException;
+import org.apache.james.mime4j.codec.DecodeMonitor;
+import org.apache.james.mime4j.dom.address.Address;
+import org.apache.james.mime4j.dom.field.AddressListField;
+import org.apache.james.mime4j.dom.field.DateTimeField;
+import org.apache.james.mime4j.dom.field.FieldName;
+import org.apache.james.mime4j.dom.field.MailboxField;
+import org.apache.james.mime4j.dom.field.MailboxListField;
+import org.apache.james.mime4j.dom.field.ParseException;
+import org.apache.james.mime4j.dom.field.UnstructuredField;
+import org.apache.james.mime4j.field.DefaultFieldParser;
+import org.apache.james.mime4j.field.Fields;
+import org.apache.james.mime4j.field.LenientFieldParser;
+import org.apache.james.mime4j.field.address.DefaultAddressParser;
+import org.apache.james.mime4j.io.InputStreams;
+import org.apache.james.mime4j.internal.AbstractEntityBuilder;
+import org.apache.james.mime4j.message.BasicBodyFactory;
+import org.apache.james.mime4j.message.BodyFactory;
+import org.apache.james.mime4j.message.DefaultBodyDescriptorBuilder;
+import org.apache.james.mime4j.message.HeaderImpl;
+import org.apache.james.mime4j.message.MessageImpl;
+import org.apache.james.mime4j.message.MultipartBuilder;
+import org.apache.james.mime4j.internal.ParserStreamContentHandler;
+import org.apache.james.mime4j.parser.MimeStreamParser;
+import org.apache.james.mime4j.stream.BodyDescriptorBuilder;
+import org.apache.james.mime4j.stream.Field;
+import org.apache.james.mime4j.stream.MimeConfig;
+import org.apache.james.mime4j.stream.NameValuePair;
 
 /**
  * An MIME message (as defined in RFC 2045).
@@ -108,4 +147,878 @@ public interface Message extends Entity, Body {
      */
     AddressList getReplyTo();
 
+    class Builder extends AbstractEntityBuilder {
+        private MimeConfig config;
+        private DecodeMonitor monitor;
+        private BodyDescriptorBuilder bodyDescBuilder;
+        private FieldParser<?> fieldParser;
+        private BodyFactory bodyFactory;
+        private boolean flatMode;
+        private boolean rawContent;
+
+        private Builder() {
+            super();
+        }
+
+        public static Builder of() {
+            return new Builder();
+        }
+
+        public static Builder of(Message other) {
+            return new Builder().copy(other);
+        }
+
+        public static Builder of(final InputStream is) throws IOException {
+            return new Builder().parse(is);
+        }
+
+        /**
+         * Sets MIME configuration.
+         *
+         * @param config the configuration.
+         */
+        public Builder use(MimeConfig config) {
+            this.config = config;
+            return this;
+        }
+
+        /**
+         * Sets {@link org.apache.james.mime4j.codec.DecodeMonitor} that will be
+         * used to handle malformed data when executing {@link #parse(java.io.InputStream)}.
+         *
+         * @param monitor the decoder monitor.
+         */
+        public Builder use(DecodeMonitor monitor) {
+            this.monitor = monitor;
+            return this;
+        }
+
+        /**
+         * Sets {@link org.apache.james.mime4j.stream.BodyDescriptorBuilder} that will be
+         * used to generate body descriptors when executing {@link #parse(java.io.InputStream)}.
+         *
+         * @param bodyDescBuilder the body descriptor builder.
+         */
+        public Builder use(BodyDescriptorBuilder bodyDescBuilder) {
+            this.bodyDescBuilder = bodyDescBuilder;
+            return this;
+        }
+
+        /**
+         * Sets {@link org.apache.james.mime4j.dom.FieldParser} that will be
+         * used to generate parse message fields when executing {@link #parse(java.io.InputStream)}.
+         *
+         * @param fieldParser the field parser.
+         */
+        public Builder use(FieldParser<?> fieldParser) {
+            this.fieldParser = fieldParser;
+            return this;
+        }
+
+        /**
+         * Sets {@link org.apache.james.mime4j.message.BodyFactory} that will be
+         * used to generate message body.
+         *
+         * @param bodyFactory the body factory.
+         */
+        public Builder use(BodyFactory bodyFactory) {
+            this.bodyFactory = bodyFactory;
+            return this;
+        }
+
+        /**
+         * Enables flat parsing mode for {@link #parse(java.io.InputStream)} operation.
+         */
+        public Builder enableFlatMode() {
+            this.flatMode = true;
+            return this;
+        }
+
+        /**
+         * Disables flat parsing mode for {@link #parse(java.io.InputStream)} operation.
+         */
+        public Builder disableFlatMode() {
+            this.flatMode = false;
+            return this;
+        }
+
+        /**
+         * Enables automatic content decoding for {@link #parse(java.io.InputStream)} operation.
+         */
+        public Builder enableContentDecoding() {
+            this.rawContent = false;
+            return this;
+        }
+
+        /**
+         * Enables disable content decoding for {@link #parse(java.io.InputStream)} operation.
+         */
+        public Builder disableContentDecoding() {
+            this.rawContent = true;
+            return this;
+        }
+
+        public Builder copy(Message other) {
+            if (other == null) {
+                return this;
+            }
+            clearFields();
+            final Header otherHeader = other.getHeader();
+            if (otherHeader != null) {
+                final List<Field> otherFields = otherHeader.getFields();
+                for (Field field: otherFields) {
+                    addField(field);
+                }
+            }
+            Body body = null;
+            Body otherBody = other.getBody();
+            if (otherBody instanceof Message) {
+                body = Builder.of((Message) otherBody).build();
+            } else if (otherBody instanceof Multipart) {
+                body = MultipartBuilder.createCopy((Multipart) otherBody).build();
+            } else if (otherBody instanceof SingleBody) {
+                body = ((SingleBody) otherBody).copy();
+            }
+            setBody(body);
+            return this;
+        }
+
+        @Override
+        public Builder setField(Field field) {
+            super.setField(field);
+            return this;
+        }
+
+        @Override
+        public Builder addField(Field field) {
+            super.addField(field);
+            return this;
+        }
+
+        @Override
+        public Builder removeFields(String name) {
+            super.removeFields(name);
+            return this;
+        }
+
+        @Override
+        public Builder clearFields() {
+            super.clearFields();
+            return this;
+        }
+
+        @Override
+        public Builder setContentTransferEncoding(String contentTransferEncoding) {
+            super.setContentTransferEncoding(contentTransferEncoding);
+            return this;
+        }
+
+        @Override
+        public Builder setContentType(String mimeType, NameValuePair... parameters) {
+            super.setContentType(mimeType, parameters);
+            return this;
+        }
+
+        @Override
+        public Builder setContentDisposition(String dispositionType) {
+            super.setContentDisposition(dispositionType);
+            return this;
+        }
+
+        @Override
+        public Builder setContentDisposition(String dispositionType, String filename) {
+            super.setContentDisposition(dispositionType, filename);
+            return this;
+        }
+
+        @Override
+        public Builder setContentDisposition(String dispositionType, String filename, long size) {
+            super.setContentDisposition(dispositionType, filename, size);
+            return this;
+        }
+
+        @Override
+        public Builder setContentDisposition(String dispositionType, String filename, long size,
+                                                    Date creationDate, Date modificationDate, Date readDate) {
+            super.setContentDisposition(dispositionType, filename, size, creationDate, modificationDate, readDate);
+            return this;
+        }
+
+        @Override
+        public Builder setBody(Body body) {
+            super.setBody(body);
+            return this;
+        }
+
+        @Override
+        public Builder setBody(TextBody textBody) {
+            super.setBody(textBody);
+            return this;
+        }
+
+        @Override
+        public Builder setBody(BinaryBody binaryBody) {
+            super.setBody(binaryBody);
+            return this;
+        }
+
+        @Override
+        public Builder setBody(Multipart multipart) {
+            super.setBody(multipart);
+            return this;
+        }
+
+        @Override
+        public Builder setBody(Message message) {
+            super.setBody(message);
+            return this;
+        }
+
+        /**
+         * Sets text of this message with the charset.
+         *
+         * @param text
+         *            the text.
+         * @param charset
+         *            the charset of the text.
+         */
+        public Builder setBody(String text, Charset charset) throws IOException {
+            return setBody(text, null, charset);
+        }
+
+        /**
+         * Sets text of this message with the given MIME subtype and charset.
+         *
+         * @param text
+         *            the text.
+         * @param charset
+         *            the charset of the text.
+         * @param subtype
+         *            the text subtype (e.g. &quot;plain&quot;, &quot;html&quot; or
+         *            &quot;xml&quot;).
+         */
+        public Builder setBody(String text, String subtype, Charset charset) throws IOException {
+            String mimeType = "text/" + (subtype != null ? subtype : "plain");
+            if (charset != null) {
+                setField(Fields.contentType(mimeType, new NameValuePair("charset", charset.name())));
+            } else {
+                setField(Fields.contentType(mimeType));
+            }
+            Body textBody;
+            if (bodyFactory != null) {
+                textBody = bodyFactory.textBody(
+                    InputStreams.create(text, charset),
+                    charset != null ? charset.name() : null);
+            } else {
+                textBody = BasicBodyFactory.INSTANCE.textBody(text, charset);
+            }
+            return setBody(textBody);
+        }
+
+        /**
+         * Sets binary content of this message with the given MIME type.
+         *
+         * @param bin
+         *            the body.
+         * @param mimeType
+         *            the MIME media type of the specified body
+         *            (&quot;type/subtype&quot;).
+         */
+        public Builder setBody(byte[] bin, String mimeType) throws IOException {
+            setField(Fields.contentType(mimeType != null ? mimeType : "application/octet-stream"));
+            Body binBody;
+            if (bodyFactory != null) {
+                binBody = bodyFactory.binaryBody(InputStreams.create(bin));
+            } else {
+                binBody = BasicBodyFactory.INSTANCE.binaryBody(bin);
+            }
+            return setBody(binBody);
+        }
+
+        /**
+         * Returns the value of the <i>Message-ID</i> header field of this message
+         * or <code>null</code> if it is not present.
+         *
+         * @return the identifier of this message.
+         */
+        public String getMessageId() {
+            Field field = obtainField(FieldName.MESSAGE_ID);
+            return field != null ? field.getBody() : null;
+        }
+
+        /**
+         * Generates and sets message ID for this message.
+         *
+         * @param hostname
+         *            host name to be included in the identifier or
+         *            <code>null</code> if no host name should be included.
+         */
+        public Builder generateMessageId(String hostname) {
+            if (hostname == null) {
+                removeFields(FieldName.MESSAGE_ID);
+            } else {
+                setField(Fields.generateMessageId(hostname));
+            }
+            return this;
+        }
+
+        /**
+         * Sets message ID for this message.
+         *
+         * @param messageId
+         *            the message ID.
+         */
+        public Builder setMessageId(String messageId) {
+            if (messageId == null) {
+                removeFields(FieldName.MESSAGE_ID);
+            } else {
+                setField(Fields.messageId(messageId));
+            }
+            return this;
+        }
+
+        /**
+         * Returns the (decoded) value of the <i>Subject</i> header field of this
+         * message or <code>null</code> if it is not present.
+         *
+         * @return the subject of this message.
+         */
+        public String getSubject() {
+            UnstructuredField field = obtainField(FieldName.SUBJECT);
+            return field != null ? field.getValue() : null;
+        }
+
+        /**
+         * Sets <i>Subject</i> header field for this message. The specified
+         * string may contain non-ASCII characters, in which case it gets encoded as
+         * an 'encoded-word' automatically.
+         *
+         * @param subject
+         *            subject to set or <code>null</code> to remove the subject
+         *            header field.
+         */
+        public Builder setSubject(String subject) {
+            if (subject == null) {
+                removeFields(FieldName.SUBJECT);
+            } else {
+                setField(Fields.subject(subject));
+            }
+            return this;
+        }
+
+        /**
+         * Returns the value of the <i>Date</i> header field of this message as
+         * <code>Date</code> object or <code>null</code> if it is not present.
+         *
+         * @return the date of this message.
+         */
+        public Date getDate() {
+            DateTimeField field = obtainField(FieldName.DATE);
+            return field != null ? field.getDate() : null;
+        }
+
+        /**
+         * Sets <i>Date</i> header field for this message. This method uses the
+         * default <code>TimeZone</code> of this host to encode the specified
+         * <code>Date</code> object into a string.
+         *
+         * @param date
+         *            date to set or <code>null</code> to remove the date header
+         *            field.
+         */
+        public Builder setDate(Date date) {
+            return setDate(date, null);
+        }
+
+        /**
+         * Sets <i>Date</i> header field for this message. The specified
+         * <code>TimeZone</code> is used to encode the specified <code>Date</code>
+         * object into a string.
+         *
+         * @param date
+         *            date to set or <code>null</code> to remove the date header
+         *            field.
+         * @param zone
+         *            a time zone.
+         */
+        public Builder setDate(Date date, TimeZone zone) {
+            if (date == null) {
+                removeFields(FieldName.DATE);
+            } else {
+                setField(Fields.date(FieldName.DATE, date, zone));
+            }
+            return this;
+        }
+
+        /**
+         * Returns the value of the <i>Sender</i> header field of this message as
+         * <code>Mailbox</code> object or <code>null</code> if it is not
+         * present.
+         *
+         * @return the sender of this message.
+         */
+        public Mailbox getSender() {
+            return getMailbox(FieldName.SENDER);
+        }
+
+        /**
+         * Sets <i>Sender</i> header field of this message to the specified
+         * mailbox address.
+         *
+         * @param sender
+         *            address to set or <code>null</code> to remove the header
+         *            field.
+         */
+        public Builder setSender(Mailbox sender) {
+            return setMailbox(FieldName.SENDER, sender);
+        }
+
+        /**
+         * Sets <i>Sender</i> header field of this message to the specified
+         * mailbox address.
+         *
+         * @param sender
+         *            address to set or <code>null</code> to remove the header
+         *            field.
+         */
+        public Builder setSender(String sender) throws ParseException {
+            return setMailbox(FieldName.SENDER, sender);
+        }
+
+        /**
+         * Returns the value of the <i>From</i> header field of this message as
+         * <code>MailboxList</code> object or <code>null</code> if it is not
+         * present.
+         *
+         * @return value of the from field of this message.
+         */
+        public MailboxList getFrom() {
+            return getMailboxList(FieldName.FROM);
+        }
+
+        /**
+         * Sets <i>From</i> header field of this message to the specified
+         * mailbox address.
+         *
+         * @param from
+         *            address to set or <code>null</code> to remove the header
+         *            field.
+         */
+        public Builder setFrom(Mailbox from) {
+            return setMailboxList(FieldName.FROM, from);
+        }
+
+        /**
+         * Sets <i>From</i> header field of this message to the specified
+         * mailbox address.
+         *
+         * @param from
+         *            address to set or <code>null</code> to remove the header
+         *            field.
+         */
+        public Builder setFrom(String from) throws ParseException {
+            return setMailboxList(FieldName.FROM, from);
+        }
+
+        /**
+         * Sets <i>From</i> header field of this message to the specified
+         * mailbox addresses.
+         *
+         * @param from
+         *            addresses to set or <code>null</code> or no arguments to
+         *            remove the header field.
+         */
+        public Builder setFrom(Mailbox... from) {
+            return setMailboxList(FieldName.FROM, from);
+        }
+
+        /**
+         * Sets <i>From</i> header field of this message to the specified
+         * mailbox addresses.
+         *
+         * @param from
+         *            addresses to set or <code>null</code> or no arguments to
+         *            remove the header field.
+         */
+        public Builder setFrom(String... from) throws ParseException {
+            return setMailboxList(FieldName.FROM, from);
+        }
+
+        /**
+         * Sets <i>From</i> header field of this message to the specified
+         * mailbox addresses.
+         *
+         * @param from
+         *            addresses to set or <code>null</code> or an empty collection
+         *            to remove the header field.
+         */
+        public Builder setFrom(Collection<Mailbox> from) {
+            return setMailboxList(FieldName.FROM, from);
+        }
+
+        /**
+         * Returns the value of the <i>To</i> header field of this message as
+         * <code>AddressList</code> object or <code>null</code> if it is not
+         * present.
+         *
+         * @return value of the to field of this message.
+         */
+        public AddressList getTo() {
+            return getAddressList(FieldName.TO);
+        }
+
+        /**
+         * Sets <i>To</i> header field of this message to the specified
+         * address.
+         *
+         * @param to
+         *            address to set or <code>null</code> to remove the header
+         *            field.
+         */
+        public Builder setTo(Address to) {
+            return setAddressList(FieldName.TO, to);
+        }
+
+        /**
+         * Sets <i>To</i> header field of this message to the specified
+         * address.
+         *
+         * @param to
+         *            address to set or <code>null</code> to remove the header
+         *            field.
+         */
+        public Builder setTo(String to) throws ParseException {
+            return setAddressList(FieldName.TO, to);
+        }
+
+        /**
+         * Sets <i>To</i> header field of this message to the specified
+         * addresses.
+         *
+         * @param to
+         *            addresses to set or <code>null</code> or no arguments to
+         *            remove the header field.
+         */
+        public Builder setTo(Address... to) {
+            return setAddressList(FieldName.TO, to);
+        }
+
+        /**
+         * Sets <i>To</i> header field of this message to the specified
+         * addresses.
+         *
+         * @param to
+         *            addresses to set or <code>null</code> or no arguments to
+         *            remove the header field.
+         */
+        public Builder setTo(String... to) throws ParseException {
+            return setAddressList(FieldName.TO, to);
+        }
+
+        /**
+         * Sets <i>To</i> header field of this message to the specified
+         * addresses.
+         *
+         * @param to
+         *            addresses to set or <code>null</code> or an empty collection
+         *            to remove the header field.
+         */
+        public Builder setTo(Collection<? extends Address> to) {
+            return setAddressList(FieldName.TO, to);
+        }
+
+        /**
+         * Returns the value of the <i>Cc</i> header field of this message as
+         * <code>AddressList</code> object or <code>null</code> if it is not
+         * present.
+         *
+         * @return value of the cc field of this message.
+         */
+        public AddressList getCc() {
+            return getAddressList(FieldName.CC);
+        }
+
+        /**
+         * Sets <i>Cc</i> header field of this message to the specified
+         * address.
+         *
+         * @param cc
+         *            address to set or <code>null</code> to remove the header
+         *            field.
+         */
+        public Builder setCc(Address cc) {
+            return setAddressList(FieldName.CC, cc);
+        }
+
+        /**
+         * Sets <i>Cc</i> header field of this message to the specified
+         * addresses.
+         *
+         * @param cc
+         *            addresses to set or <code>null</code> or no arguments to
+         *            remove the header field.
+         */
+        public Builder setCc(Address... cc) {
+            return setAddressList(FieldName.CC, cc);
+        }
+
+        /**
+         * Sets <i>Cc</i> header field of this message to the specified
+         * addresses.
+         *
+         * @param cc
+         *            addresses to set or <code>null</code> or an empty collection
+         *            to remove the header field.
+         */
+        public Builder setCc(Collection<? extends Address> cc) {
+            return setAddressList(FieldName.CC, cc);
+        }
+
+        /**
+         * Returns the value of the <i>Bcc</i> header field of this message as
+         * <code>AddressList</code> object or <code>null</code> if it is not
+         * present.
+         *
+         * @return value of the bcc field of this message.
+         */
+        public AddressList getBcc() {
+            return getAddressList(FieldName.BCC);
+        }
+
+        /**
+         * Sets <i>Bcc</i> header field of this message to the specified
+         * address.
+         *
+         * @param bcc
+         *            address to set or <code>null</code> to remove the header
+         *            field.
+         */
+        public Builder setBcc(Address bcc) {
+            return setAddressList(FieldName.BCC, bcc);
+        }
+
+        /**
+         * Sets <i>Bcc</i> header field of this message to the specified
+         * addresses.
+         *
+         * @param bcc
+         *            addresses to set or <code>null</code> or no arguments to
+         *            remove the header field.
+         */
+        public Builder setBcc(Address... bcc) {
+            return setAddressList(FieldName.BCC, bcc);
+        }
+
+        /**
+         * Sets <i>Bcc</i> header field of this message to the specified
+         * addresses.
+         *
+         * @param bcc
+         *            addresses to set or <code>null</code> or an empty collection
+         *            to remove the header field.
+         */
+        public Builder setBcc(Collection<? extends Address> bcc) {
+            return setAddressList(FieldName.BCC, bcc);
+        }
+
+        /**
+         * Returns the value of the <i>Reply-To</i> header field of this message as
+         * <code>AddressList</code> object or <code>null</code> if it is not
+         * present.
+         *
+         * @return value of the reply to field of this message.
+         */
+        public AddressList getReplyTo() {
+            return getAddressList(FieldName.REPLY_TO);
+        }
+
+        /**
+         * Sets <i>Reply-To</i> header field of this message to the specified
+         * address.
+         *
+         * @param replyTo
+         *            address to set or <code>null</code> to remove the header
+         *            field.
+         */
+        public Builder setReplyTo(Address replyTo) {
+            return setAddressList(FieldName.REPLY_TO, replyTo);
+        }
+
+        /**
+         * Sets <i>Reply-To</i> header field of this message to the specified
+         * addresses.
+         *
+         * @param replyTo
+         *            addresses to set or <code>null</code> or no arguments to
+         *            remove the header field.
+         */
+        public Builder setReplyTo(Address... replyTo) {
+            return setAddressList(FieldName.REPLY_TO, replyTo);
+        }
+
+        /**
+         * Sets <i>Reply-To</i> header field of this message to the specified
+         * addresses.
+         *
+         * @param replyTo
+         *            addresses to set or <code>null</code> or an empty collection
+         *            to remove the header field.
+         */
+        public Builder setReplyTo(Collection<? extends Address> replyTo) {
+            return setAddressList(FieldName.REPLY_TO, replyTo);
+        }
+
+        public Builder parse(final InputStream is) throws IOException {
+            MimeConfig currentConfig = config != null ? config : MimeConfig.DEFAULT;
+            boolean strict = currentConfig.isStrictParsing();
+            DecodeMonitor currentMonitor = monitor != null ? monitor : strict ? DecodeMonitor.STRICT : DecodeMonitor.SILENT;
+            BodyDescriptorBuilder currentBodyDescBuilder = bodyDescBuilder != null ? bodyDescBuilder :
+                new DefaultBodyDescriptorBuilder(null, fieldParser != null ? fieldParser :
+                    strict ? DefaultFieldParser.getParser() : LenientFieldParser.getParser(), currentMonitor);
+            BodyFactory currentBodyFactory = bodyFactory != null ? bodyFactory : new BasicBodyFactory(!strict);
+            MimeStreamParser parser = new MimeStreamParser(currentConfig, currentMonitor, currentBodyDescBuilder);
+
+            Message message = new MessageImpl();
+            parser.setContentHandler(new ParserStreamContentHandler(message, currentBodyFactory));
+            parser.setContentDecoding(!rawContent);
+            if (flatMode) {
+                parser.setFlat();
+            }
+            try {
+                parser.parse(is);
+            } catch (MimeException e) {
+                throw new MimeIOException(e);
+            }
+            clearFields();
+            final List<Field> fields = message.getHeader().getFields();
+            for (Field field: fields) {
+                addField(field);
+            }
+            setBody(message.getBody());
+            return this;
+        }
+
+        public Message build() {
+            MessageImpl message = new MessageImpl();
+            HeaderImpl header = new HeaderImpl();
+            message.setHeader(header);
+            if (!containsField(FieldName.MIME_VERSION)) {
+                header.setField(Fields.version("1.0"));
+            }
+            for (Field field : getFields()) {
+                header.addField(field);
+            }
+
+            message.setBody(getBody());
+
+            return message;
+        }
+
+        private Mailbox getMailbox(String fieldName) {
+            MailboxField field = obtainField(fieldName);
+            return field != null ? field.getMailbox() : null;
+        }
+
+        private Builder setMailbox(String fieldName, Mailbox mailbox) {
+            if (mailbox == null) {
+                removeFields(fieldName);
+            } else {
+                setField(Fields.mailbox(fieldName, mailbox));
+            }
+            return this;
+        }
+
+        private Builder setMailbox(String fieldName, String mailbox) throws ParseException {
+            if (mailbox == null) {
+                removeFields(fieldName);
+            } else {
+                setField(Fields.mailbox(fieldName, DefaultAddressParser.DEFAULT.parseMailbox(mailbox)));
+            }
+            return this;
+        }
+
+        private MailboxList getMailboxList(String fieldName) {
+            MailboxListField field = obtainField(fieldName);
+            return field != null ? field.getMailboxList() : null;
+        }
+
+        private Builder setMailboxList(String fieldName, Mailbox mailbox) {
+            return setMailboxList(fieldName, mailbox == null ? null : Collections.singleton(mailbox));
+        }
+
+        private Builder setMailboxList(String fieldName, String mailbox) throws ParseException {
+            return setMailboxList(fieldName, mailbox == null ? null : DefaultAddressParser.DEFAULT.parseMailbox(mailbox));
+        }
+
+        private Builder setMailboxList(String fieldName, Mailbox... mailboxes) {
+            return setMailboxList(fieldName, mailboxes == null ? null : Arrays.asList(mailboxes));
+        }
+
+        private List<Mailbox> parseMailboxes(String... mailboxes) throws ParseException {
+            if (mailboxes == null || mailboxes.length == 0) {
+                return null;
+            } else {
+                List<Mailbox> list = new ArrayList<Mailbox>();
+                for (String mailbox: mailboxes) {
+                    list.add(DefaultAddressParser.DEFAULT.parseMailbox(mailbox));
+                }
+                return list;
+            }
+        }
+
+        private Builder setMailboxList(String fieldName, String... mailboxes) throws ParseException {
+            return setMailboxList(fieldName, parseMailboxes(mailboxes));
+        }
+
+        private Builder setMailboxList(String fieldName, Collection<Mailbox> mailboxes) {
+            if (mailboxes == null || mailboxes.isEmpty()) {
+                removeFields(fieldName);
+            } else {
+                setField(Fields.mailboxList(fieldName, mailboxes));
+            }
+            return this;
+        }
+
+        private AddressList getAddressList(String fieldName) {
+            AddressListField field = obtainField(fieldName);
+            return field != null? field.getAddressList() : null;
+        }
+
+        private Builder setAddressList(String fieldName, Address address) {
+            return setAddressList(fieldName, address == null ? null : Collections.singleton(address));
+        }
+
+        private Builder setAddressList(String fieldName, String address) throws ParseException {
+            return setAddressList(fieldName, address == null ? null : DefaultAddressParser.DEFAULT.parseMailbox(address));
+        }
+
+        private Builder setAddressList(String fieldName, Address... addresses) {
+            return setAddressList(fieldName, addresses == null ? null : Arrays.asList(addresses));
+        }
+
+        private List<Address> parseAddresses(String... addresses) throws ParseException {
+            if (addresses == null || addresses.length == 0) {
+                return null;
+            } else {
+                List<Address> list = new ArrayList<Address>();
+                for (String address: addresses) {
+                    list.add(DefaultAddressParser.DEFAULT.parseAddress(address));
+                }
+                return list;
+            }
+        }
+
+        private Builder setAddressList(String fieldName, String... addresses) throws ParseException {
+            return setAddressList(fieldName, parseAddresses(addresses));
+        }
+
+        private Builder setAddressList(String fieldName, Collection<? extends Address> addresses) {
+            if (addresses == null || addresses.isEmpty()) {
+                removeFields(fieldName);
+            } else {
+                setField(Fields.addressList(fieldName, addresses));
+            }
+            return this;
+        }
+    }
 }

--- a/dom/src/main/java/org/apache/james/mime4j/internal/AbstractEntityBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/internal/AbstractEntityBuilder.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mime4j.message;
+package org.apache.james.mime4j.internal;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,14 +44,14 @@ import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.NameValuePair;
 import org.apache.james.mime4j.util.MimeUtil;
 
-abstract class AbstractEntityBuilder {
+public abstract class AbstractEntityBuilder {
 
     private final List<Field> fields;
     private final Map<String, List<Field>> fieldMap;
 
     private Body body;
 
-    AbstractEntityBuilder() {
+    public AbstractEntityBuilder() {
         this.fields = new LinkedList<Field>();
         this.fieldMap = new HashMap<String, List<Field>>();
     }
@@ -241,7 +241,7 @@ abstract class AbstractEntityBuilder {
     }
 
     @SuppressWarnings("unchecked")
-    <F extends ParsedField> F obtainField(String fieldName) {
+    public <F extends ParsedField> F obtainField(String fieldName) {
         return (F) getField(fieldName);
     }
 

--- a/dom/src/main/java/org/apache/james/mime4j/internal/ParserStreamContentHandler.java
+++ b/dom/src/main/java/org/apache/james/mime4j/internal/ParserStreamContentHandler.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mime4j.message;
+package org.apache.james.mime4j.internal;
 
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.dom.Body;
@@ -25,6 +25,12 @@ import org.apache.james.mime4j.dom.Entity;
 import org.apache.james.mime4j.dom.Header;
 import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.dom.Multipart;
+import org.apache.james.mime4j.message.BodyFactory;
+import org.apache.james.mime4j.message.BodyPart;
+import org.apache.james.mime4j.message.DefaultMessageImplFactory;
+import org.apache.james.mime4j.message.HeaderImpl;
+import org.apache.james.mime4j.message.MessageImplFactory;
+import org.apache.james.mime4j.message.MultipartImpl;
 import org.apache.james.mime4j.parser.ContentHandler;
 import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
@@ -39,14 +45,14 @@ import java.util.Stack;
  * A <code>ContentHandler</code> for building an <code>Entity</code> to be
  * used in conjunction with a {@link org.apache.james.mime4j.parser.MimeStreamParser}.
  */
-class ParserStreamContentHandler implements ContentHandler {
+public class ParserStreamContentHandler implements ContentHandler {
 
     private final Entity entity;
     private final MessageImplFactory messageImplFactory;
     private final BodyFactory bodyFactory;
     private final Stack<Object> stack;
 
-    ParserStreamContentHandler(
+    public ParserStreamContentHandler(
             final Entity entity,
             final BodyFactory bodyFactory) {
         this.entity = entity;
@@ -55,7 +61,7 @@ class ParserStreamContentHandler implements ContentHandler {
         this.stack = new Stack<Object>();
     }
 
-    ParserStreamContentHandler(
+    public ParserStreamContentHandler(
             final Entity entity,
             final MessageImplFactory messageImplFactory,
             final BodyFactory bodyFactory) {

--- a/dom/src/main/java/org/apache/james/mime4j/message/BodyPartBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/BodyPartBuilder.java
@@ -29,6 +29,7 @@ import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.dom.Multipart;
 import org.apache.james.mime4j.dom.TextBody;
 import org.apache.james.mime4j.field.Fields;
+import org.apache.james.mime4j.internal.AbstractEntityBuilder;
 import org.apache.james.mime4j.io.InputStreams;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.NameValuePair;

--- a/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/DefaultMessageBuilder.java
@@ -37,6 +37,7 @@ import org.apache.james.mime4j.dom.SingleBody;
 import org.apache.james.mime4j.dom.field.ParsedField;
 import org.apache.james.mime4j.field.DefaultFieldParser;
 import org.apache.james.mime4j.field.LenientFieldParser;
+import org.apache.james.mime4j.internal.ParserStreamContentHandler;
 import org.apache.james.mime4j.parser.AbstractContentHandler;
 import org.apache.james.mime4j.parser.MimeStreamParser;
 import org.apache.james.mime4j.stream.BodyDescriptorBuilder;

--- a/dom/src/main/java/org/apache/james/mime4j/message/MessageBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/MessageBuilder.java
@@ -19,978 +19,498 @@
 
 package org.apache.james.mime4j.message;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.TimeZone;
-
-import org.apache.james.mime4j.MimeException;
-import org.apache.james.mime4j.MimeIOException;
 import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.dom.BinaryBody;
 import org.apache.james.mime4j.dom.Body;
 import org.apache.james.mime4j.dom.FieldParser;
-import org.apache.james.mime4j.dom.Header;
 import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.dom.Multipart;
-import org.apache.james.mime4j.dom.SingleBody;
 import org.apache.james.mime4j.dom.TextBody;
 import org.apache.james.mime4j.dom.address.Address;
 import org.apache.james.mime4j.dom.address.AddressList;
 import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.dom.address.MailboxList;
-import org.apache.james.mime4j.dom.field.AddressListField;
-import org.apache.james.mime4j.dom.field.DateTimeField;
-import org.apache.james.mime4j.dom.field.FieldName;
-import org.apache.james.mime4j.dom.field.MailboxField;
-import org.apache.james.mime4j.dom.field.MailboxListField;
 import org.apache.james.mime4j.dom.field.ParseException;
-import org.apache.james.mime4j.dom.field.UnstructuredField;
-import org.apache.james.mime4j.field.DefaultFieldParser;
-import org.apache.james.mime4j.field.Fields;
-import org.apache.james.mime4j.field.LenientFieldParser;
-import org.apache.james.mime4j.field.address.DefaultAddressParser;
-import org.apache.james.mime4j.io.InputStreams;
-import org.apache.james.mime4j.parser.MimeStreamParser;
+import org.apache.james.mime4j.dom.field.ParsedField;
 import org.apache.james.mime4j.stream.BodyDescriptorBuilder;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
 import org.apache.james.mime4j.stream.NameValuePair;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
 /**
- * {@link org.apache.james.mime4j.dom.Message} builder.
+ * Deprecated: please use {@link org.apache.james.mime4j.dom.Message.Builder Message.Builder} instead
+ * This builder will create message that do not respect the
+ * <code>Message.getDate()</code> contract regarding the return
+ * value when the message do not have a Date header
+ * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
  */
-public class MessageBuilder extends AbstractEntityBuilder {
+@Deprecated
+@SuppressWarnings("deprecation")
+public class MessageBuilder {
+    private final Message.Builder builder;
 
-    private MimeConfig config;
-    private DecodeMonitor monitor;
-    private BodyDescriptorBuilder bodyDescBuilder;
-    private FieldParser<?> fieldParser;
-    private BodyFactory bodyFactory;
-    private boolean flatMode;
-    private boolean rawContent;
-    private final boolean ensureDateNotNull;
-
-    /**
-     * Deprecated: please use {@link #of() of} instead
-     * Building a builder using this method will result in a buggy builder which
-     * will create message that do not respect the <code>Message.getDate()</code> contract regarding
-     * the return value when the message do not have a Date header
-     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
-     */
-    @Deprecated
     public MessageBuilder() {
-        this(true);
+        this(Message.Builder.of());
     }
 
-    private MessageBuilder(boolean ensureDateNotNull) {
-        this.ensureDateNotNull = ensureDateNotNull;
+    private MessageBuilder(Message.Builder builder) {
+        this.builder = builder;
     }
 
-    public static MessageBuilder of() {
-        return new MessageBuilder(false);
-    }
-
-    /**
-     * Deprecated: please use {@link #of() of} instead
-     * Building a builder using this method will result in a buggy builder which
-     * will create message that do not respect the <code>Message.getDate()</code> contract regarding
-     * the return value when the message do not have a Date header
-     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
-     */
-    @Deprecated
     public static MessageBuilder create() {
-        return new MessageBuilder(true);
+        return new MessageBuilder();
     }
 
-    public static MessageBuilder of(Message other) {
-        return new MessageBuilder(false).copy(other);
-    }
-
-    /**
-     * Deprecated: please use {@link #of(Message) of} instead
-     * Building a builder using this method will result in a buggy builder which
-     * will create message that do not respect the <code>Message.getDate()</code> contract regarding
-     * the return value when the message do not have a Date header
-     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
-     */
-    @Deprecated
     public static MessageBuilder createCopy(Message other) {
-        return new MessageBuilder().copy(other);
+        return new MessageBuilder(Message.Builder.of(other));
     }
 
-    public static MessageBuilder of(final InputStream is) throws IOException {
-        return new MessageBuilder(false).parse(is);
+    public static MessageBuilder read(InputStream is) throws IOException {
+        return new MessageBuilder(Message.Builder.of(is));
     }
 
-    /**
-     * Deprecated: please use {@link #of(InputStream) of} instead
-     * Building a builder using this method will result in a buggy builder which
-     * will create message that do not respect the <code>Message.getDate()</code> contract regarding
-     * the return value when the message do not have a Date header
-     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
-     */
-    @Deprecated
-    public static MessageBuilder read(final InputStream is) throws IOException {
-        return new MessageBuilder().parse(is);
-    }
 
-    /**
-     * Sets MIME configuration.
-     *
-     * @param config the configuration.
-     */
-    public MessageBuilder use(MimeConfig config) {
-        this.config = config;
-        return this;
-    }
-
-    /**
-     * Sets {@link org.apache.james.mime4j.codec.DecodeMonitor} that will be
-     * used to handle malformed data when executing {@link #parse(java.io.InputStream)}.
-     *
-     * @param monitor the decoder monitor.
-     */
-    public MessageBuilder use(DecodeMonitor monitor) {
-        this.monitor = monitor;
-        return this;
-    }
-
-    /**
-     * Sets {@link org.apache.james.mime4j.stream.BodyDescriptorBuilder} that will be
-     * used to generate body descriptors when executing {@link #parse(java.io.InputStream)}.
-     *
-     * @param bodyDescBuilder the body descriptor builder.
-     */
-    public MessageBuilder use(BodyDescriptorBuilder bodyDescBuilder) {
-        this.bodyDescBuilder = bodyDescBuilder;
-        return this;
-    }
-
-    /**
-     * Sets {@link org.apache.james.mime4j.dom.FieldParser} that will be
-     * used to generate parse message fields when executing {@link #parse(java.io.InputStream)}.
-     *
-     * @param fieldParser the field parser.
-     */
-    public MessageBuilder use(FieldParser<?> fieldParser) {
-        this.fieldParser = fieldParser;
-        return this;
-    }
-
-    /**
-     * Sets {@link org.apache.james.mime4j.message.BodyFactory} that will be
-     * used to generate message body.
-     *
-     * @param bodyFactory the body factory.
-     */
-    public MessageBuilder use(BodyFactory bodyFactory) {
-        this.bodyFactory = bodyFactory;
-        return this;
-    }
-
-    /**
-     * Enables flat parsing mode for {@link #parse(java.io.InputStream)} operation.
-     */
     public MessageBuilder enableFlatMode() {
-        this.flatMode = true;
+        builder.enableFlatMode();
+
         return this;
     }
 
-    /**
-     * Disables flat parsing mode for {@link #parse(java.io.InputStream)} operation.
-     */
     public MessageBuilder disableFlatMode() {
-        this.flatMode = false;
+        builder.disableFlatMode();
+
         return this;
     }
 
-    /**
-     * Enables automatic content decoding for {@link #parse(java.io.InputStream)} operation.
-     */
     public MessageBuilder enableContentDecoding() {
-        this.rawContent = false;
+        builder.enableContentDecoding();
+
         return this;
     }
 
-    /**
-     * Enables disable content decoding for {@link #parse(java.io.InputStream)} operation.
-     */
     public MessageBuilder disableContentDecoding() {
-        this.rawContent = true;
+        builder.disableContentDecoding();
+
         return this;
     }
 
-    @Override
     public MessageBuilder setField(Field field) {
-        super.setField(field);
+        builder.setField(field);
+
         return this;
     }
 
-    @Override
     public MessageBuilder addField(Field field) {
-        super.addField(field);
+        builder.addField(field);
+
         return this;
     }
 
-    @Override
+    public Field getField(String name) {
+        return builder.getField(name);
+    }
+
+    public <F extends Field> F getField(final String name, final Class<F> clazz) {
+        return builder.getField(name, clazz);
+    }
+
+    public List<Field> getFields() {
+        return builder.getFields();
+    }
+
+    public <F extends Field> List<F> getFields(final String name, final Class<F> clazz) {
+        return builder.getFields(name, clazz);
+    }
+
     public MessageBuilder removeFields(String name) {
-        super.removeFields(name);
+        builder.removeFields(name);
+
         return this;
     }
 
-    @Override
     public MessageBuilder clearFields() {
-        super.clearFields();
+        builder.clearFields();
+
         return this;
     }
 
-    @Override
-    public MessageBuilder setContentTransferEncoding(String contentTransferEncoding) {
-        super.setContentTransferEncoding(contentTransferEncoding);
-        return this;
+    public boolean containsField(String name) {
+        return builder.containsField(name);
     }
 
-    @Override
+    public String getMimeType() {
+        return builder.getMimeType();
+    }
+
+    public String getCharset() {
+        return builder.getCharset();
+    }
+
+    public String getContentTransferEncoding() {
+        return builder.getContentTransferEncoding();
+    }
+
     public MessageBuilder setContentType(String mimeType, NameValuePair... parameters) {
-        super.setContentType(mimeType, parameters);
+        builder.setContentType(mimeType, parameters);
+
         return this;
     }
 
-    @Override
+    public MessageBuilder setContentTransferEncoding(String contentTransferEncoding) {
+        builder.setContentTransferEncoding(contentTransferEncoding);
+
+        return this;
+    }
+
+    public String getDispositionType() {
+        return builder.getDispositionType();
+    }
+
     public MessageBuilder setContentDisposition(String dispositionType) {
-        super.setContentDisposition(dispositionType);
+        builder.setContentDisposition(dispositionType);
+
         return this;
     }
 
-    @Override
     public MessageBuilder setContentDisposition(String dispositionType, String filename) {
-        super.setContentDisposition(dispositionType, filename);
+        builder.setContentDisposition(dispositionType, filename);
+
         return this;
     }
 
-    @Override
     public MessageBuilder setContentDisposition(String dispositionType, String filename, long size) {
-        super.setContentDisposition(dispositionType, filename, size);
+        builder.setContentDisposition(dispositionType, filename, size);
+
         return this;
     }
 
-    @Override
-    public MessageBuilder setContentDisposition(String dispositionType, String filename, long size,
-                                                Date creationDate, Date modificationDate, Date readDate) {
-        super.setContentDisposition(dispositionType, filename, size, creationDate, modificationDate, readDate);
+    public MessageBuilder setContentDisposition(String dispositionType, String filename, long size, Date creationDate, Date modificationDate, Date readDate) {
+        builder.setContentDisposition(dispositionType, filename, size, creationDate, modificationDate, readDate);
+
         return this;
     }
 
-    @Override
-    public MessageBuilder setBody(Body body) {
-        super.setBody(body);
-        return this;
+    public Body getBody() {
+        return builder.getBody();
     }
 
-    @Override
-    public MessageBuilder setBody(TextBody textBody) {
-        super.setBody(textBody);
-        return this;
-    }
-
-    @Override
-    public MessageBuilder setBody(BinaryBody binaryBody) {
-        super.setBody(binaryBody);
-        return this;
-    }
-
-    @Override
     public MessageBuilder setBody(Multipart multipart) {
-        super.setBody(multipart);
+        builder.setBody(multipart);
+
         return this;
     }
 
-    @Override
     public MessageBuilder setBody(Message message) {
-        super.setBody(message);
+        builder.setBody(message);
+
         return this;
     }
 
-    /**
-     * Sets text of this message with the charset.
-     *
-     * @param text
-     *            the text.
-     * @param charset
-     *            the charset of the text.
-     */
+    public MessageBuilder setBody(Body body) {
+        builder.setBody(body);
+
+        return this;
+    }
+
+    public MessageBuilder setBody(TextBody textBody) {
+        builder.setBody(textBody);
+
+        return this;
+    }
+
+    public MessageBuilder setBody(BinaryBody binaryBody) {
+        builder.setBody(binaryBody);
+
+        return this;
+    }
+
     public MessageBuilder setBody(String text, Charset charset) throws IOException {
-        return setBody(text, null, charset);
+        builder.setBody(text, charset);
+
+        return this;
     }
 
-    /**
-     * Sets text of this message with the given MIME subtype and charset.
-     *
-     * @param text
-     *            the text.
-     * @param charset
-     *            the charset of the text.
-     * @param subtype
-     *            the text subtype (e.g. &quot;plain&quot;, &quot;html&quot; or
-     *            &quot;xml&quot;).
-     */
     public MessageBuilder setBody(String text, String subtype, Charset charset) throws IOException {
-        String mimeType = "text/" + (subtype != null ? subtype : "plain");
-        if (charset != null) {
-            setField(Fields.contentType(mimeType, new NameValuePair("charset", charset.name())));
-        } else {
-            setField(Fields.contentType(mimeType));
-        }
-        Body textBody;
-        if (bodyFactory != null) {
-            textBody = bodyFactory.textBody(
-                    InputStreams.create(text, charset),
-                    charset != null ? charset.name() : null);
-        } else {
-            textBody = BasicBodyFactory.INSTANCE.textBody(text, charset);
-        }
-        return setBody(textBody);
+        builder.setBody(text, subtype, charset);
+
+        return this;
     }
 
-    /**
-     * Sets binary content of this message with the given MIME type.
-     *
-     * @param bin
-     *            the body.
-     * @param mimeType
-     *            the MIME media type of the specified body
-     *            (&quot;type/subtype&quot;).
-     */
     public MessageBuilder setBody(byte[] bin, String mimeType) throws IOException {
-        setField(Fields.contentType(mimeType != null ? mimeType : "application/octet-stream"));
-        Body binBody;
-        if (bodyFactory != null) {
-            binBody = bodyFactory.binaryBody(InputStreams.create(bin));
-        } else {
-            binBody = BasicBodyFactory.INSTANCE.binaryBody(bin);
-        }
-        return setBody(binBody);
+        builder.setBody(bin, mimeType);
+
+        return this;
     }
 
-    /**
-     * Returns the value of the <i>Message-ID</i> header field of this message
-     * or <code>null</code> if it is not present.
-     *
-     * @return the identifier of this message.
-     */
+
+    public String getFilename() {
+        return builder.getFilename();
+    }
+
+    public long getSize() {
+        return builder.getSize();
+    }
+
+    public Date getCreationDate() {
+        return builder.getCreationDate();
+    }
+
+    public Date getModificationDate() {
+        return builder.getModificationDate();
+    }
+
+    public Date getReadDate() {
+        return getReadDate();
+    }
+
     public String getMessageId() {
-        Field field = obtainField(FieldName.MESSAGE_ID);
-        return field != null ? field.getBody() : null;
+        return builder.getMessageId();
     }
 
-    /**
-     * Generates and sets message ID for this message.
-     *
-     * @param hostname
-     *            host name to be included in the identifier or
-     *            <code>null</code> if no host name should be included.
-     */
-    public MessageBuilder generateMessageId(String hostname) {
-        if (hostname == null) {
-            removeFields(FieldName.MESSAGE_ID);
-        } else {
-            setField(Fields.generateMessageId(hostname));
-        }
-        return this;
-    }
-
-    /**
-     * Sets message ID for this message.
-     *
-     * @param messageId
-     *            the message ID.
-     */
     public MessageBuilder setMessageId(String messageId) {
-        if (messageId == null) {
-            removeFields(FieldName.MESSAGE_ID);
-        } else {
-            setField(Fields.messageId(messageId));
-        }
+        builder.setMessageId(messageId);
+
         return this;
     }
 
-    /**
-     * Returns the (decoded) value of the <i>Subject</i> header field of this
-     * message or <code>null</code> if it is not present.
-     *
-     * @return the subject of this message.
-     */
+    public MessageBuilder generateMessageId(String hostname) {
+        builder.generateMessageId(hostname);
+
+        return this;
+    }
+
     public String getSubject() {
-        UnstructuredField field = obtainField(FieldName.SUBJECT);
-        return field != null ? field.getValue() : null;
+        return builder.getSubject();
     }
 
-    /**
-     * Sets <i>Subject</i> header field for this message. The specified
-     * string may contain non-ASCII characters, in which case it gets encoded as
-     * an 'encoded-word' automatically.
-     *
-     * @param subject
-     *            subject to set or <code>null</code> to remove the subject
-     *            header field.
-     */
     public MessageBuilder setSubject(String subject) {
-        if (subject == null) {
-            removeFields(FieldName.SUBJECT);
-        } else {
-            setField(Fields.subject(subject));
-        }
+        builder.setSubject(subject);
+
         return this;
     }
 
-    /**
-     * Returns the value of the <i>Date</i> header field of this message as
-     * <code>Date</code> object or <code>null</code> if it is not present.
-     *
-     * @return the date of this message.
-     */
     public Date getDate() {
-        DateTimeField field = obtainField(FieldName.DATE);
-        return field != null ? field.getDate() : null;
+        return builder.getDate();
     }
 
-    /**
-     * Sets <i>Date</i> header field for this message. This method uses the
-     * default <code>TimeZone</code> of this host to encode the specified
-     * <code>Date</code> object into a string.
-     *
-     * @param date
-     *            date to set or <code>null</code> to remove the date header
-     *            field.
-     */
     public MessageBuilder setDate(Date date) {
-        return setDate(date, null);
+        builder.setDate(date);
+
+        return this;
     }
 
-    /**
-     * Sets <i>Date</i> header field for this message. The specified
-     * <code>TimeZone</code> is used to encode the specified <code>Date</code>
-     * object into a string.
-     *
-     * @param date
-     *            date to set or <code>null</code> to remove the date header
-     *            field.
-     * @param zone
-     *            a time zone.
-     */
     public MessageBuilder setDate(Date date, TimeZone zone) {
-        if (date == null) {
-            removeFields(FieldName.DATE);
-        } else {
-            setField(Fields.date(FieldName.DATE, date, zone));
-        }
+        builder.setDate(date, zone);
+
         return this;
     }
 
-    /**
-     * Returns the value of the <i>Sender</i> header field of this message as
-     * <code>Mailbox</code> object or <code>null</code> if it is not
-     * present.
-     *
-     * @return the sender of this message.
-     */
     public Mailbox getSender() {
-        return getMailbox(FieldName.SENDER);
+        return builder.getSender();
     }
 
-    /**
-     * Sets <i>Sender</i> header field of this message to the specified
-     * mailbox address.
-     *
-     * @param sender
-     *            address to set or <code>null</code> to remove the header
-     *            field.
-     */
     public MessageBuilder setSender(Mailbox sender) {
-        return setMailbox(FieldName.SENDER, sender);
+        builder.setSender(sender);
+
+        return this;
     }
 
-    /**
-     * Sets <i>Sender</i> header field of this message to the specified
-     * mailbox address.
-     *
-     * @param sender
-     *            address to set or <code>null</code> to remove the header
-     *            field.
-     */
     public MessageBuilder setSender(String sender) throws ParseException {
-        return setMailbox(FieldName.SENDER, sender);
+        builder.setSender(sender);
+
+        return this;
     }
 
-    /**
-     * Returns the value of the <i>From</i> header field of this message as
-     * <code>MailboxList</code> object or <code>null</code> if it is not
-     * present.
-     *
-     * @return value of the from field of this message.
-     */
     public MailboxList getFrom() {
-        return getMailboxList(FieldName.FROM);
+        return builder.getFrom();
     }
 
-    /**
-     * Sets <i>From</i> header field of this message to the specified
-     * mailbox address.
-     *
-     * @param from
-     *            address to set or <code>null</code> to remove the header
-     *            field.
-     */
-    public MessageBuilder setFrom(Mailbox from) {
-        return setMailboxList(FieldName.FROM, from);
-    }
-
-    /**
-     * Sets <i>From</i> header field of this message to the specified
-     * mailbox address.
-     *
-     * @param from
-     *            address to set or <code>null</code> to remove the header
-     *            field.
-     */
-    public MessageBuilder setFrom(String from) throws ParseException {
-        return setMailboxList(FieldName.FROM, from);
-    }
-
-    /**
-     * Sets <i>From</i> header field of this message to the specified
-     * mailbox addresses.
-     *
-     * @param from
-     *            addresses to set or <code>null</code> or no arguments to
-     *            remove the header field.
-     */
-    public MessageBuilder setFrom(Mailbox... from) {
-        return setMailboxList(FieldName.FROM, from);
-    }
-
-    /**
-     * Sets <i>From</i> header field of this message to the specified
-     * mailbox addresses.
-     *
-     * @param from
-     *            addresses to set or <code>null</code> or no arguments to
-     *            remove the header field.
-     */
     public MessageBuilder setFrom(String... from) throws ParseException {
-        return setMailboxList(FieldName.FROM, from);
+        builder.setFrom(from);
+
+        return this;
     }
 
-    /**
-     * Sets <i>From</i> header field of this message to the specified
-     * mailbox addresses.
-     *
-     * @param from
-     *            addresses to set or <code>null</code> or an empty collection
-     *            to remove the header field.
-     */
     public MessageBuilder setFrom(Collection<Mailbox> from) {
-        return setMailboxList(FieldName.FROM, from);
+        builder.setFrom(from);
+
+        return this;
     }
 
-    /**
-     * Returns the value of the <i>To</i> header field of this message as
-     * <code>AddressList</code> object or <code>null</code> if it is not
-     * present.
-     *
-     * @return value of the to field of this message.
-     */
+    public MessageBuilder setFrom(Mailbox from) {
+        builder.setFrom(from);
+
+        return this;
+    }
+
+    public MessageBuilder setFrom(String from) throws ParseException {
+        builder.setFrom(from);
+
+        return this;
+    }
+
+    public MessageBuilder setFrom(Mailbox... from) {
+        builder.setFrom(from);
+
+        return this;
+    }
+
     public AddressList getTo() {
-        return getAddressList(FieldName.TO);
+        return builder.getTo();
     }
 
-    /**
-     * Sets <i>To</i> header field of this message to the specified
-     * address.
-     *
-     * @param to
-     *            address to set or <code>null</code> to remove the header
-     *            field.
-     */
-    public MessageBuilder setTo(Address to) {
-        return setAddressList(FieldName.TO, to);
-    }
-
-    /**
-     * Sets <i>To</i> header field of this message to the specified
-     * address.
-     *
-     * @param to
-     *            address to set or <code>null</code> to remove the header
-     *            field.
-     */
-    public MessageBuilder setTo(String to) throws ParseException {
-        return setAddressList(FieldName.TO, to);
-    }
-
-    /**
-     * Sets <i>To</i> header field of this message to the specified
-     * addresses.
-     *
-     * @param to
-     *            addresses to set or <code>null</code> or no arguments to
-     *            remove the header field.
-     */
-    public MessageBuilder setTo(Address... to) {
-        return setAddressList(FieldName.TO, to);
-    }
-
-    /**
-     * Sets <i>To</i> header field of this message to the specified
-     * addresses.
-     *
-     * @param to
-     *            addresses to set or <code>null</code> or no arguments to
-     *            remove the header field.
-     */
     public MessageBuilder setTo(String... to) throws ParseException {
-        return setAddressList(FieldName.TO, to);
+        builder.setTo(to);
+
+        return this;
     }
 
-    /**
-     * Sets <i>To</i> header field of this message to the specified
-     * addresses.
-     *
-     * @param to
-     *            addresses to set or <code>null</code> or an empty collection
-     *            to remove the header field.
-     */
     public MessageBuilder setTo(Collection<? extends Address> to) {
-        return setAddressList(FieldName.TO, to);
+        builder.setTo(to);
+
+        return this;
     }
 
-    /**
-     * Returns the value of the <i>Cc</i> header field of this message as
-     * <code>AddressList</code> object or <code>null</code> if it is not
-     * present.
-     *
-     * @return value of the cc field of this message.
-     */
+    public MessageBuilder setTo(Address to) {
+        builder.setTo(to);
+
+        return this;
+    }
+
+    public MessageBuilder setTo(String to) throws ParseException {
+        builder.setTo(to);
+
+        return this;
+    }
+
+    public MessageBuilder setTo(Address... to) {
+        builder.setTo(to);
+
+        return this;
+    }
+
     public AddressList getCc() {
-        return getAddressList(FieldName.CC);
+        return builder.getCc();
     }
 
-    /**
-     * Sets <i>Cc</i> header field of this message to the specified
-     * address.
-     *
-     * @param cc
-     *            address to set or <code>null</code> to remove the header
-     *            field.
-     */
-    public MessageBuilder setCc(Address cc) {
-        return setAddressList(FieldName.CC, cc);
-    }
-
-    /**
-     * Sets <i>Cc</i> header field of this message to the specified
-     * addresses.
-     *
-     * @param cc
-     *            addresses to set or <code>null</code> or no arguments to
-     *            remove the header field.
-     */
     public MessageBuilder setCc(Address... cc) {
-        return setAddressList(FieldName.CC, cc);
+        builder.setCc(cc);
+
+        return this;
     }
 
-    /**
-     * Sets <i>Cc</i> header field of this message to the specified
-     * addresses.
-     *
-     * @param cc
-     *            addresses to set or <code>null</code> or an empty collection
-     *            to remove the header field.
-     */
     public MessageBuilder setCc(Collection<? extends Address> cc) {
-        return setAddressList(FieldName.CC, cc);
+        builder.setCc(cc);
+
+        return this;
     }
 
-    /**
-     * Returns the value of the <i>Bcc</i> header field of this message as
-     * <code>AddressList</code> object or <code>null</code> if it is not
-     * present.
-     *
-     * @return value of the bcc field of this message.
-     */
+    public MessageBuilder setCc(Address cc) {
+        builder.setCc(cc);
+
+        return this;
+    }
+
     public AddressList getBcc() {
-        return getAddressList(FieldName.BCC);
+        return builder.getBcc();
     }
 
-    /**
-     * Sets <i>Bcc</i> header field of this message to the specified
-     * address.
-     *
-     * @param bcc
-     *            address to set or <code>null</code> to remove the header
-     *            field.
-     */
-    public MessageBuilder setBcc(Address bcc) {
-        return setAddressList(FieldName.BCC, bcc);
-    }
-
-    /**
-     * Sets <i>Bcc</i> header field of this message to the specified
-     * addresses.
-     *
-     * @param bcc
-     *            addresses to set or <code>null</code> or no arguments to
-     *            remove the header field.
-     */
     public MessageBuilder setBcc(Address... bcc) {
-        return setAddressList(FieldName.BCC, bcc);
+        builder.setBcc(bcc);
+
+        return this;
     }
 
-    /**
-     * Sets <i>Bcc</i> header field of this message to the specified
-     * addresses.
-     *
-     * @param bcc
-     *            addresses to set or <code>null</code> or an empty collection
-     *            to remove the header field.
-     */
     public MessageBuilder setBcc(Collection<? extends Address> bcc) {
-        return setAddressList(FieldName.BCC, bcc);
-    }
+        builder.setBcc(bcc);
 
-    /**
-     * Returns the value of the <i>Reply-To</i> header field of this message as
-     * <code>AddressList</code> object or <code>null</code> if it is not
-     * present.
-     *
-     * @return value of the reply to field of this message.
-     */
-    public AddressList getReplyTo() {
-        return getAddressList(FieldName.REPLY_TO);
-    }
-
-    /**
-     * Sets <i>Reply-To</i> header field of this message to the specified
-     * address.
-     *
-     * @param replyTo
-     *            address to set or <code>null</code> to remove the header
-     *            field.
-     */
-    public MessageBuilder setReplyTo(Address replyTo) {
-        return setAddressList(FieldName.REPLY_TO, replyTo);
-    }
-
-    /**
-     * Sets <i>Reply-To</i> header field of this message to the specified
-     * addresses.
-     *
-     * @param replyTo
-     *            addresses to set or <code>null</code> or no arguments to
-     *            remove the header field.
-     */
-    public MessageBuilder setReplyTo(Address... replyTo) {
-        return setAddressList(FieldName.REPLY_TO, replyTo);
-    }
-
-    /**
-     * Sets <i>Reply-To</i> header field of this message to the specified
-     * addresses.
-     *
-     * @param replyTo
-     *            addresses to set or <code>null</code> or an empty collection
-     *            to remove the header field.
-     */
-    public MessageBuilder setReplyTo(Collection<? extends Address> replyTo) {
-        return setAddressList(FieldName.REPLY_TO, replyTo);
-    }
-
-    private Mailbox getMailbox(String fieldName) {
-        MailboxField field = obtainField(fieldName);
-        return field != null ? field.getMailbox() : null;
-    }
-
-    private MessageBuilder setMailbox(String fieldName, Mailbox mailbox) {
-        if (mailbox == null) {
-            removeFields(fieldName);
-        } else {
-            setField(Fields.mailbox(fieldName, mailbox));
-        }
         return this;
     }
 
-    private MessageBuilder setMailbox(String fieldName, String mailbox) throws ParseException {
-        if (mailbox == null) {
-            removeFields(fieldName);
-        } else {
-            setField(Fields.mailbox(fieldName, DefaultAddressParser.DEFAULT.parseMailbox(mailbox)));
-        }
-        return this;
-    }
+    public MessageBuilder setBcc(Address bcc) {
+        builder.setBcc(bcc);
 
-    private MailboxList getMailboxList(String fieldName) {
-        MailboxListField field = obtainField(fieldName);
-        return field != null ? field.getMailboxList() : null;
-    }
-
-    private MessageBuilder setMailboxList(String fieldName, Mailbox mailbox) {
-        return setMailboxList(fieldName, mailbox == null ? null : Collections.singleton(mailbox));
-    }
-
-    private MessageBuilder setMailboxList(String fieldName, String mailbox) throws ParseException {
-        return setMailboxList(fieldName, mailbox == null ? null : DefaultAddressParser.DEFAULT.parseMailbox(mailbox));
-    }
-
-    private MessageBuilder setMailboxList(String fieldName, Mailbox... mailboxes) {
-        return setMailboxList(fieldName, mailboxes == null ? null : Arrays.asList(mailboxes));
-    }
-
-    private List<Mailbox> parseMailboxes(String... mailboxes) throws ParseException {
-        if (mailboxes == null || mailboxes.length == 0) {
-            return null;
-        } else {
-            List<Mailbox> list = new ArrayList<Mailbox>();
-            for (String mailbox: mailboxes) {
-                list.add(DefaultAddressParser.DEFAULT.parseMailbox(mailbox));
-            }
-            return list;
-        }
-    }
-
-    private MessageBuilder setMailboxList(String fieldName, String... mailboxes) throws ParseException {
-        return setMailboxList(fieldName, parseMailboxes(mailboxes));
-    }
-
-    private MessageBuilder setMailboxList(String fieldName, Collection<Mailbox> mailboxes) {
-        if (mailboxes == null || mailboxes.isEmpty()) {
-            removeFields(fieldName);
-        } else {
-            setField(Fields.mailboxList(fieldName, mailboxes));
-        }
-        return this;
-    }
-
-    private AddressList getAddressList(String fieldName) {
-        AddressListField field = obtainField(fieldName);
-        return field != null? field.getAddressList() : null;
-    }
-
-    private MessageBuilder setAddressList(String fieldName, Address address) {
-        return setAddressList(fieldName, address == null ? null : Collections.singleton(address));
-    }
-
-    private MessageBuilder setAddressList(String fieldName, String address) throws ParseException {
-        return setAddressList(fieldName, address == null ? null : DefaultAddressParser.DEFAULT.parseMailbox(address));
-    }
-
-    private MessageBuilder setAddressList(String fieldName, Address... addresses) {
-        return setAddressList(fieldName, addresses == null ? null : Arrays.asList(addresses));
-    }
-
-    private List<Address> parseAddresses(String... addresses) throws ParseException {
-        if (addresses == null || addresses.length == 0) {
-            return null;
-        } else {
-            List<Address> list = new ArrayList<Address>();
-            for (String address: addresses) {
-                list.add(DefaultAddressParser.DEFAULT.parseAddress(address));
-            }
-            return list;
-        }
-    }
-
-    private MessageBuilder setAddressList(String fieldName, String... addresses) throws ParseException {
-        return setAddressList(fieldName, parseAddresses(addresses));
-    }
-
-    private MessageBuilder setAddressList(String fieldName, Collection<? extends Address> addresses) {
-        if (addresses == null || addresses.isEmpty()) {
-            removeFields(fieldName);
-        } else {
-            setField(Fields.addressList(fieldName, addresses));
-        }
         return this;
     }
 
     public MessageBuilder copy(Message other) {
-        if (other == null) {
-            return this;
-        }
-        clearFields();
-        final Header otherHeader = other.getHeader();
-        if (otherHeader != null) {
-            final List<Field> otherFields = otherHeader.getFields();
-            for (Field field: otherFields) {
-                addField(field);
-            }
-        }
-        Body body = null;
-        Body otherBody = other.getBody();
-        if (otherBody instanceof Message) {
-            body = MessageBuilder.createCopy((Message) otherBody).build();
-        } else if (otherBody instanceof Multipart) {
-            body = MultipartBuilder.createCopy((Multipart) otherBody).build();
-        } else if (otherBody instanceof SingleBody) {
-            body = ((SingleBody) otherBody).copy();
-        }
-        setBody(body);
+        builder.copy(other);
+
         return this;
     }
 
-    public MessageBuilder parse(final InputStream is) throws IOException {
-        MimeConfig currentConfig = config != null ? config : MimeConfig.DEFAULT;
-        boolean strict = currentConfig.isStrictParsing();
-        DecodeMonitor currentMonitor = monitor != null ? monitor : strict ? DecodeMonitor.STRICT : DecodeMonitor.SILENT;
-        BodyDescriptorBuilder currentBodyDescBuilder = bodyDescBuilder != null ? bodyDescBuilder :
-                new DefaultBodyDescriptorBuilder(null, fieldParser != null ? fieldParser :
-                        strict ? DefaultFieldParser.getParser() : LenientFieldParser.getParser(), currentMonitor);
-        BodyFactory currentBodyFactory = bodyFactory != null ? bodyFactory : new BasicBodyFactory(!strict);
-        MimeStreamParser parser = new MimeStreamParser(currentConfig, currentMonitor, currentBodyDescBuilder);
+    public MessageBuilder parse(InputStream is) throws IOException {
+        builder.parse(is);
 
-        Message message = new MessageImpl();
-        parser.setContentHandler(new ParserStreamContentHandler(message, currentBodyFactory));
-        parser.setContentDecoding(!rawContent);
-        if (flatMode) {
-            parser.setFlat();
-        }
-        try {
-            parser.parse(is);
-        } catch (MimeException e) {
-            throw new MimeIOException(e);
-        }
-        clearFields();
-        final List<Field> fields = message.getHeader().getFields();
-        for (Field field: fields) {
-            addField(field);
-        }
-        setBody(message.getBody());
+        return this;
+    }
+
+    public AddressList getReplyTo() {
+        return builder.getReplyTo();
+    }
+
+    public MessageBuilder setReplyTo(Address... replyTo) {
+        builder.setReplyTo(replyTo);
+
+        return this;
+    }
+
+    public MessageBuilder setReplyTo(Collection<? extends Address> replyTo) {
+        builder.setReplyTo(replyTo);
+
+        return this;
+    }
+
+    public MessageBuilder setReplyTo(Address replyTo) {
+        builder.setReplyTo(replyTo);
+
+        return this;
+    }
+
+    public MessageBuilder use(MimeConfig config) {
+        builder.use(config);
+
+        return this;
+    }
+
+    public MessageBuilder use(DecodeMonitor monitor) {
+        builder.use(monitor);
+
+        return this;
+    }
+
+    public MessageBuilder use(BodyDescriptorBuilder bodyDescBuilder) {
+        builder.use(bodyDescBuilder);
+
+        return this;
+    }
+
+    public MessageBuilder use(FieldParser<?> fieldParser) {
+        builder.use(fieldParser);
+
+        return this;
+    }
+
+    public MessageBuilder use(BodyFactory bodyFactory) {
+        builder.use(bodyFactory);
+
         return this;
     }
 
     public Message build() {
-        MessageImpl message = new MessageImpl();
-        HeaderImpl header = new HeaderImpl();
-        message.setHeader(header);
-        if (!containsField(FieldName.MIME_VERSION)) {
-            header.setField(Fields.version("1.0"));
-        }
-        for (Field field : getFields()) {
-            header.addField(field);
-        }
-        if (ensureDateNotNull && !containsField(FieldName.DATE)) {
-            header.setField(Fields.date(new Date()));
+        if (getDate() == null) {
+            setDate(new Date());
         }
 
-        message.setBody(getBody());
-
-        return message;
+        return builder.build();
     }
 
 }

--- a/dom/src/main/java/org/apache/james/mime4j/message/MessageBuilder.java
+++ b/dom/src/main/java/org/apache/james/mime4j/message/MessageBuilder.java
@@ -75,15 +75,68 @@ public class MessageBuilder extends AbstractEntityBuilder {
     private BodyFactory bodyFactory;
     private boolean flatMode;
     private boolean rawContent;
+    private final boolean ensureDateNotNull;
 
-    public static MessageBuilder create() {
-        return new MessageBuilder();
+    /**
+     * Deprecated: please use {@link #of() of} instead
+     * Building a builder using this method will result in a buggy builder which
+     * will create message that do not respect the <code>Message.getDate()</code> contract regarding
+     * the return value when the message do not have a Date header
+     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
+     */
+    @Deprecated
+    public MessageBuilder() {
+        this(true);
     }
 
+    private MessageBuilder(boolean ensureDateNotNull) {
+        this.ensureDateNotNull = ensureDateNotNull;
+    }
+
+    public static MessageBuilder of() {
+        return new MessageBuilder(false);
+    }
+
+    /**
+     * Deprecated: please use {@link #of() of} instead
+     * Building a builder using this method will result in a buggy builder which
+     * will create message that do not respect the <code>Message.getDate()</code> contract regarding
+     * the return value when the message do not have a Date header
+     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
+     */
+    @Deprecated
+    public static MessageBuilder create() {
+        return new MessageBuilder(true);
+    }
+
+    public static MessageBuilder of(Message other) {
+        return new MessageBuilder(false).copy(other);
+    }
+
+    /**
+     * Deprecated: please use {@link #of(Message) of} instead
+     * Building a builder using this method will result in a buggy builder which
+     * will create message that do not respect the <code>Message.getDate()</code> contract regarding
+     * the return value when the message do not have a Date header
+     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
+     */
+    @Deprecated
     public static MessageBuilder createCopy(Message other) {
         return new MessageBuilder().copy(other);
     }
 
+    public static MessageBuilder of(final InputStream is) throws IOException {
+        return new MessageBuilder(false).parse(is);
+    }
+
+    /**
+     * Deprecated: please use {@link #of(InputStream) of} instead
+     * Building a builder using this method will result in a buggy builder which
+     * will create message that do not respect the <code>Message.getDate()</code> contract regarding
+     * the return value when the message do not have a Date header
+     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
+     */
+    @Deprecated
     public static MessageBuilder read(final InputStream is) throws IOException {
         return new MessageBuilder().parse(is);
     }
@@ -931,7 +984,7 @@ public class MessageBuilder extends AbstractEntityBuilder {
         for (Field field : getFields()) {
             header.addField(field);
         }
-        if (!containsField(FieldName.DATE)) {
+        if (ensureDateNotNull && !containsField(FieldName.DATE)) {
             header.setField(Fields.date(new Date()));
         }
 

--- a/dom/src/test/java/org/apache/james/mime4j/dom/MessageTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/dom/MessageTest.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mime4j.message;
+package org.apache.james.mime4j.dom;
 
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
@@ -26,9 +26,6 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import org.apache.james.mime4j.Charsets;
-import org.apache.james.mime4j.dom.BinaryBody;
-import org.apache.james.mime4j.dom.Message;
-import org.apache.james.mime4j.dom.TextBody;
 import org.apache.james.mime4j.dom.address.AddressList;
 import org.apache.james.mime4j.dom.address.Group;
 import org.apache.james.mime4j.dom.address.Mailbox;
@@ -38,16 +35,17 @@ import org.apache.james.mime4j.dom.field.FieldName;
 import org.apache.james.mime4j.field.DefaultFieldParser;
 import org.apache.james.mime4j.field.Fields;
 import org.apache.james.mime4j.field.address.DefaultAddressParser;
+import org.apache.james.mime4j.message.BasicBodyFactory;
+import org.apache.james.mime4j.message.BodyFactory;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-@SuppressWarnings("deprecation")
-public class MessageBuilderTest {
+public class MessageTest {
 
     @Test
     public void testSetCustomBody() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         BodyFactory bodyFactory = Mockito.spy(new BasicBodyFactory());
         builder.use(bodyFactory);
@@ -91,7 +89,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetMessageId() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         String id = "<msg17@localhost>";
         builder.setMessageId(id);
@@ -100,7 +98,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testCreateMessageId() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
         builder.generateMessageId("hostname");
 
         String id = builder.getMessageId();
@@ -111,7 +109,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetSubject() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
         Assert.assertNull(builder.getSubject());
 
         String subject = "testing 1 2";
@@ -124,7 +122,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetSubject() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         builder.setSubject("Semmelbr\366sel");
         Assert.assertEquals("Semmelbr\366sel", builder.getSubject());
@@ -137,7 +135,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetDate() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
         Assert.assertNull(builder.getDate());
 
         builder.setField(DefaultFieldParser.parse("Date: Thu, 1 Jan 1970 05:30:00 +0530"));
@@ -147,7 +145,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetDate() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         builder.setDate(new Date(86400000), TimeZone.getTimeZone("GMT"));
         Assert.assertEquals(new Date(86400000), builder.getDate());
@@ -160,7 +158,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetSender() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
         Assert.assertNull(builder.getSender());
 
         builder.setField(DefaultFieldParser.parse("Sender: john.doe@example.net"));
@@ -170,7 +168,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetSender() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         builder.setSender("john.doe@example.net");
         Assert.assertEquals("john.doe@example.net", builder.getField("Sender").getBody());
@@ -181,7 +179,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetFrom() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
         Assert.assertNull(builder.getFrom());
 
         builder.setField(DefaultFieldParser.parse("From: john.doe@example.net"));
@@ -191,7 +189,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetFrom() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -214,7 +212,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetTo() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
         Assert.assertNull(builder.getTo());
 
         builder.setField(DefaultFieldParser.parse("To: john.doe@example.net"));
@@ -225,7 +223,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetTo() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -252,7 +250,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetCc() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
         Assert.assertNull(builder.getCc());
 
         builder.setField(DefaultFieldParser.parse("Cc: john.doe@example.net"));
@@ -263,7 +261,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetCc() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -290,7 +288,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetBcc() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
         Assert.assertNull(builder.getBcc());
 
         builder.setField(DefaultFieldParser.parse("Bcc: john.doe@example.net"));
@@ -301,7 +299,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetBcc() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -328,7 +326,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetReplyTo() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
         Assert.assertNull(builder.getReplyTo());
 
         builder.setField(DefaultFieldParser.parse("Reply-To: john.doe@example.net"));
@@ -339,7 +337,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetReplyTo() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        Message.Builder builder = Message.Builder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -366,7 +364,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testBuildWithDefaults() throws Exception {
-        Message message = MessageBuilder.create()
+        Message message = Message.Builder.of()
                 .generateMessageId("hostname")
                 .setSubject("testing ...")
                 .setFrom("batman@localhost", "superman@localhost")
@@ -376,7 +374,7 @@ public class MessageBuilderTest {
 
         Assert.assertEquals("text/plain", message.getMimeType());
         Assert.assertNotNull(message.getMessageId());
-        Assert.assertNotNull(message.getDate());
+        Assert.assertNull(message.getDate());
         Assert.assertEquals("1.0", message.getHeader().getField(FieldName.MIME_VERSION).getBody());
         Assert.assertEquals("testing ...", message.getSubject());
         Assert.assertEquals(new MailboxList(
@@ -394,7 +392,7 @@ public class MessageBuilderTest {
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         Date date = dateFormat.parse("2014-08-01 12:00");
 
-        Message message = MessageBuilder.create()
+        Message message = Message.Builder.of()
                 .setMessageId("blah@hostname")
                 .setDate(date)
                 .addField(Fields.version("1.0.1"))
@@ -419,8 +417,8 @@ public class MessageBuilderTest {
     }
 
     @Test
-    public void testCopy() throws Exception {
-        Message original = MessageBuilder.create()
+    public void testOfOnBuilder() throws Exception {
+        Message original = Message.Builder.of()
                 .generateMessageId("hostname")
                 .setSubject("testing ...")
                 .setFrom("batman@localhost", "superman@localhost")
@@ -428,7 +426,7 @@ public class MessageBuilderTest {
                 .setBody("Yo, big momma!", Charsets.UTF_8)
                 .build();
 
-        MessageBuilder builder = MessageBuilder.createCopy(original);
+        Message.Builder builder = Message.Builder.of(original);
         Assert.assertEquals(original.getHeader().getFields(), builder.getFields());
         Assert.assertNotSame(original.getBody(), builder.getBody());
         Assert.assertSame(original.getBody().getClass(), builder.getBody().getClass());

--- a/dom/src/test/java/org/apache/james/mime4j/message/AbstractEntityBuilderTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/message/AbstractEntityBuilderTest.java
@@ -33,6 +33,7 @@ import org.apache.james.mime4j.dom.field.ContentTransferEncodingField;
 import org.apache.james.mime4j.dom.field.ContentTypeField;
 import org.apache.james.mime4j.dom.field.ParsedField;
 import org.apache.james.mime4j.field.DefaultFieldParser;
+import org.apache.james.mime4j.internal.AbstractEntityBuilder;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.NameValuePair;
 import org.junit.Assert;

--- a/dom/src/test/java/org/apache/james/mime4j/message/MessageBuilderTest.java
+++ b/dom/src/test/java/org/apache/james/mime4j/message/MessageBuilderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mime4j.message;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -46,7 +47,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetCustomBody() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         BodyFactory bodyFactory = Mockito.spy(new BasicBodyFactory());
         builder.use(bodyFactory);
@@ -90,7 +91,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetMessageId() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         String id = "<msg17@localhost>";
         builder.setMessageId(id);
@@ -99,7 +100,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testCreateMessageId() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
         builder.generateMessageId("hostname");
 
         String id = builder.getMessageId();
@@ -110,7 +111,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetSubject() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
         Assert.assertNull(builder.getSubject());
 
         String subject = "testing 1 2";
@@ -123,7 +124,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetSubject() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         builder.setSubject("Semmelbr\366sel");
         Assert.assertEquals("Semmelbr\366sel", builder.getSubject());
@@ -136,7 +137,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetDate() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
         Assert.assertNull(builder.getDate());
 
         builder.setField(DefaultFieldParser.parse("Date: Thu, 1 Jan 1970 05:30:00 +0530"));
@@ -146,7 +147,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetDate() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         builder.setDate(new Date(86400000), TimeZone.getTimeZone("GMT"));
         Assert.assertEquals(new Date(86400000), builder.getDate());
@@ -159,7 +160,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetSender() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
         Assert.assertNull(builder.getSender());
 
         builder.setField(DefaultFieldParser.parse("Sender: john.doe@example.net"));
@@ -169,7 +170,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetSender() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         builder.setSender("john.doe@example.net");
         Assert.assertEquals("john.doe@example.net", builder.getField("Sender").getBody());
@@ -180,7 +181,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetFrom() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
         Assert.assertNull(builder.getFrom());
 
         builder.setField(DefaultFieldParser.parse("From: john.doe@example.net"));
@@ -190,7 +191,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetFrom() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -213,7 +214,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetTo() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
         Assert.assertNull(builder.getTo());
 
         builder.setField(DefaultFieldParser.parse("To: john.doe@example.net"));
@@ -224,7 +225,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetTo() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -251,7 +252,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetCc() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
         Assert.assertNull(builder.getCc());
 
         builder.setField(DefaultFieldParser.parse("Cc: john.doe@example.net"));
@@ -262,7 +263,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetCc() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -289,7 +290,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetBcc() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
         Assert.assertNull(builder.getBcc());
 
         builder.setField(DefaultFieldParser.parse("Bcc: john.doe@example.net"));
@@ -300,7 +301,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetBcc() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -327,7 +328,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testGetReplyTo() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
         Assert.assertNull(builder.getReplyTo());
 
         builder.setField(DefaultFieldParser.parse("Reply-To: john.doe@example.net"));
@@ -338,7 +339,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testSetReplyTo() throws Exception {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder builder = MessageBuilder.of();
 
         Mailbox mailbox1 = DefaultAddressParser.DEFAULT.parseMailbox("john.doe@example.net");
         Mailbox mailbox2 = DefaultAddressParser.DEFAULT.parseMailbox("jane.doe@example.net");
@@ -365,7 +366,7 @@ public class MessageBuilderTest {
 
     @Test
     public void testBuildWithDefaults() throws Exception {
-        Message message = MessageBuilder.create()
+        Message message = MessageBuilder.of()
                 .generateMessageId("hostname")
                 .setSubject("testing ...")
                 .setFrom("batman@localhost", "superman@localhost")
@@ -375,7 +376,7 @@ public class MessageBuilderTest {
 
         Assert.assertEquals("text/plain", message.getMimeType());
         Assert.assertNotNull(message.getMessageId());
-        Assert.assertNotNull(message.getDate());
+        Assert.assertNull(message.getDate());
         Assert.assertEquals("1.0", message.getHeader().getField(FieldName.MIME_VERSION).getBody());
         Assert.assertEquals("testing ...", message.getSubject());
         Assert.assertEquals(new MailboxList(
@@ -387,13 +388,116 @@ public class MessageBuilderTest {
         Assert.assertEquals("UTF-8", message.getCharset());
     }
 
+    /**
+     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
+     */
+    @Test
+    public void testThatDeprecatedCreateNeverReturnNullDate() throws Exception {
+        @SuppressWarnings("deprecation") MessageBuilder builder = MessageBuilder.create();
+
+        Message message = builder.generateMessageId("hostname")
+            .setSubject("testing ...")
+            .setFrom("batman@localhost", "superman@localhost")
+            .setTo("\"Big momma\" <big_momma@localhost>")
+            .setBody("Yo, big momma!", Charsets.UTF_8)
+            .build();
+
+        Assert.assertNotNull(message.getDate());
+    }
+
+    /**
+     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
+     */
+    @Test
+    public void testThatDeprecatedConstructorNeverReturnNullDate() throws Exception {
+        @SuppressWarnings("deprecation") MessageBuilder builder = new MessageBuilder();
+
+        Message message = builder.generateMessageId("hostname")
+            .setSubject("testing ...")
+            .setFrom("batman@localhost", "superman@localhost")
+            .setTo("\"Big momma\" <big_momma@localhost>")
+            .setBody("Yo, big momma!", Charsets.UTF_8)
+            .build();
+
+        Assert.assertNotNull(message.getDate());
+    }
+
+    /**
+     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
+     */
+    @Test
+    public void testThatDeprecatedCreateCopyNeverReturnNullDate() throws Exception {
+        Message messageWithoutDate = MessageBuilder.of().generateMessageId("hostname")
+            .setSubject("testing ...")
+            .setFrom("batman@localhost", "superman@localhost")
+            .setTo("\"Big momma\" <big_momma@localhost>")
+            .setBody("Yo, big momma!", Charsets.UTF_8)
+            .build();
+
+        @SuppressWarnings("deprecation") MessageBuilder builder = MessageBuilder.createCopy(messageWithoutDate);
+
+        Message testee = builder.build();
+
+        Assert.assertNotNull(testee.getDate());
+    }
+
+
+    @Test
+    public void testThatOfMesageReturnNullDateWhenNoDateHeader() throws Exception {
+        Message messageWithoutDate = MessageBuilder.of().generateMessageId("hostname")
+            .setSubject("testing ...")
+            .setFrom("batman@localhost", "superman@localhost")
+            .setTo("\"Big momma\" <big_momma@localhost>")
+            .setBody("Yo, big momma!", Charsets.UTF_8)
+            .build();
+
+        MessageBuilder builder = MessageBuilder.of(messageWithoutDate);
+
+        Message testee = builder.build();
+
+        Assert.assertNull(testee.getDate());
+    }
+
+    /**
+     * See <a href="https://issues.apache.org/jira/browse/MIME4J-262">MIME4J-262</a>
+     */
+    @Test
+    public void testThatDeprecatedReadNeverReturnNullDate() throws Exception {
+        String messageSource = "To: me ME <me@me.com>\n" +
+            "From: you YOU <you@you.com>\n" +
+            "Subject: message\n" +
+            "MIME-Version: 1.0\n" +
+            "\n" +
+            "This is a message";
+
+        @SuppressWarnings("deprecation") MessageBuilder builder = MessageBuilder.read(new ByteArrayInputStream(messageSource.getBytes()));
+        Message testee = builder.build();
+
+        Assert.assertNotNull(testee.getDate());
+    }
+
+    @Test
+    public void testThatOfInputStreamReturnNullDateWhenNoDateHeader() throws Exception {
+        String messageSource = "To: me ME <me@me.com>\n" +
+            "From: you YOU <you@you.com>\n" +
+            "Subject: message\n" +
+            "MIME-Version: 1.0\n" +
+            "\n" +
+            "This is a message";
+
+        @SuppressWarnings("deprecation") MessageBuilder builder = MessageBuilder.of(new ByteArrayInputStream(messageSource.getBytes()));
+        Message testee = builder.build();
+
+        Assert.assertNull(testee.getDate());
+    }
+
     @Test
     public void testBuildWithNoDefaults() throws Exception {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         Date date = dateFormat.parse("2014-08-01 12:00");
 
-        Message message = MessageBuilder.create()
+        Message message = MessageBuilder.of()
                 .setMessageId("blah@hostname")
                 .setDate(date)
                 .addField(Fields.version("1.0.1"))
@@ -418,8 +522,8 @@ public class MessageBuilderTest {
     }
 
     @Test
-    public void testCopy() throws Exception {
-        Message original = MessageBuilder.create()
+    public void testOfWithAMessage() throws Exception {
+        Message original = MessageBuilder.of()
                 .generateMessageId("hostname")
                 .setSubject("testing ...")
                 .setFrom("batman@localhost", "superman@localhost")
@@ -427,7 +531,7 @@ public class MessageBuilderTest {
                 .setBody("Yo, big momma!", Charsets.UTF_8)
                 .build();
 
-        MessageBuilder builder = MessageBuilder.createCopy(original);
+        MessageBuilder builder = MessageBuilder.of(original);
         Assert.assertEquals(original.getHeader().getFields(), builder.getFields());
         Assert.assertNotSame(original.getBody(), builder.getBody());
         Assert.assertSame(original.getBody().getClass(), builder.getBody().getClass());

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.james</groupId>
     <artifactId>apache-mime4j-project</artifactId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache James :: Mime4j :: Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.james</groupId>
     <artifactId>apache-mime4j-project</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.8.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache James :: Mime4j :: Project</name>


### PR DESCRIPTION
Before MessageBuilder produces message that had a getDate that was returning a
non null date instead of null when the message had no "Date" header.

In order to not break old code that do not check for null value, old way to
create a builder has been kept and depreciated. Those old way return a builder
that act exactly the same than before.

New way of building a MessageBuilder has been added and do create a builder that
are not buggy anymore.